### PR TITLE
Added `ValueConverter`s

### DIFF
--- a/source/SharedMauiCoreLibrary/SharedMauiCoreLibrary/Converters/DoubleValueToColorConverter.cs
+++ b/source/SharedMauiCoreLibrary/SharedMauiCoreLibrary/Converters/DoubleValueToColorConverter.cs
@@ -1,0 +1,47 @@
+﻿using System.Globalization;
+
+namespace AndreasReitberger.Shared.Core.Converters
+{
+    public class DoubleValueToColorConverter : BindableObject, IValueConverter, IMarkupExtension<DoubleValueToColorConverter>
+    {
+        #region Fields
+        public static readonly BindableProperty OnZeroProperty =
+            BindableProperty.Create(nameof(OnZero), typeof(Color), typeof(DoubleValueToColorConverter), Colors.Gray, BindingMode.TwoWay, null, null);
+
+        public static readonly BindableProperty OnPositiveProperty =
+            BindableProperty.Create(nameof(OnPositive), typeof(Color), typeof(DoubleValueToColorConverter), Colors.Green, BindingMode.TwoWay, null, null);
+
+        public static readonly BindableProperty OnNegativeProperty =
+            BindableProperty.Create(nameof(OnNegative), typeof(Color), typeof(DoubleValueToColorConverter), Colors.Red, BindingMode.TwoWay, null, null);
+
+        #endregion
+
+        public Color OnZero { get; set; } = Colors.Gray;
+        public Color OnPositive { get; set; } = Colors.Green;
+        public Color OnNegative { get; set; } = Colors.Red;
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is not double doubleValue || targetType != typeof(Color)) return null;
+            return doubleValue switch
+            {
+                > 0 => OnPositive,
+                < 0 => OnNegative,
+                _ => OnZero,
+            };
+        }
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+
+        public object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return this;
+        }
+
+        DoubleValueToColorConverter IMarkupExtension<DoubleValueToColorConverter>.ProvideValue(IServiceProvider serviceProvider)
+        {
+            return this;
+        }
+    }
+}

--- a/source/SharedMauiCoreLibrary/SharedMauiCoreLibrary/Converters/DoubleValueToIconConverter.cs
+++ b/source/SharedMauiCoreLibrary/SharedMauiCoreLibrary/Converters/DoubleValueToIconConverter.cs
@@ -1,0 +1,35 @@
+﻿using System.Globalization;
+
+namespace AndreasReitberger.Shared.Core.Converters
+{
+    public class DoubleValueToIconConverter : IValueConverter, IMarkupExtension<DoubleValueToIconConverter>
+    {
+        public string OnZero { get; set; } = string.Empty;
+        public string OnPositive { get; set; } = string.Empty;
+        public string OnNegative { get; set; } = string.Empty;
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is not double doubleValue || targetType != typeof(string)) return null;
+            return doubleValue switch
+            {
+                > 0 => OnPositive,
+                < 0 => OnNegative,
+                _ => OnZero,
+            };
+        }
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+
+        public object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return this;
+        }
+
+        DoubleValueToIconConverter IMarkupExtension<DoubleValueToIconConverter>.ProvideValue(IServiceProvider serviceProvider)
+        {
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds two `ValueConverter` converting a `Double` value to a `Color` and `String`. Those converters allows to bind a color/string for three states.

- Equal (change == 0)
- Greater (change > 0)
- Lower (change < 0).

This is used in our Stocks-Monitor app to set the color/icon for the stock rate change.