### PR TITLE
Added `List` extensions

### DIFF
--- a/src/SharedMauiCoreLibrary/Extensions/ListExtensions.cs
+++ b/src/SharedMauiCoreLibrary/Extensions/ListExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System.Reflection;
+using System.Xml;
+
+namespace AndreasReitberger.Shared.Core.Extensions
+{
+    public static class ListExtensions
+    {
+        public static IEnumerable<List<T>> Split<T>(this List<T> source, int size)
+        {
+            return source
+                .Select((x, i) => new { Index = i, Value = x })
+                .GroupBy(x => x.Index / size)
+                .Select(x => x.Select(v => v.Value).ToList())
+                .ToList();
+        }
+    }
+}

--- a/src/SharedMauiCoreLibrary/Utilities/CollectionHelper.cs
+++ b/src/SharedMauiCoreLibrary/Utilities/CollectionHelper.cs
@@ -1,0 +1,14 @@
+﻿namespace AndreasReitberger.Shared.Core.Utilities
+{
+    public static class CollectionHelper
+    {
+        public static IEnumerable<List<T>> Split<T>(List<T> source, int size)
+        {
+            return source
+                .Select((x, i) => new { Index = i, Value = x })
+                .GroupBy(x => x.Index / size)
+                .Select(x => x.Select(v => v.Value).ToList())
+                .ToList();
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a `List` extension to `Split` up lists.

Fixed #57