### PR TITLE
Updated readme for `Licensing`

### DIFF
--- a/README_Licensing.md
+++ b/README_Licensing.md
@@ -1,0 +1,81 @@
+# SharedMauiCoreLibrary.Licensing
+A shared library, which enables licensing of your .NET MAUI applications.
+
+# Dependencies
+This extension needs a WooCommerce powered store and the WP Software License Plugin (https://wpsoftwarelicense.com/)
+
+# Documentation
+Learn more here:
+https://andreas-reitberger.de/en/docs/programmieren/net-maui-basis-applikation-app-template/lizenz-manager/
+
+# Nuget
+Get the latest version from nuget.org<br>
+[![NuGet](https://img.shields.io/nuget/v/SharedMauiCoreLibrary.Licensing.svg?style=flat-square&label=nuget)](https://www.nuget.org/packages/SharedMauiCoreLibrary.Licensing/)
+[![NuGet](https://img.shields.io/nuget/dt/SharedMauiCoreLibrary.Licensing.svg)](https://www.nuget.org/packages/SharedMauiCoreLibrary.Licensing)
+
+## Available content
+Please find a list of available content below.
+
+### Usage
+
+#### Namespace
+```xaml
+xmlns:behaviors="clr-namespace:AndreasReitberger.Shared.Core.Licensing;assembly=SharedMauiCoreLibrary.Licensing"
+```
+
+```cs
+using AndreasReitberger.Shared.Core.Licensing
+```
+
+#### LicenseManager
+In order to use `LicenseManager`, create a new `Instance` like shown below. .
+
+```cs
+string licenseUri = "andreas-reitberger.de";
+LicenseManager manager;
+
+//....
+
+manager = new LicenseManager.LicenseManagerConnectionBuilder()
+            .WithLicenseServer(serverAddress: licenseUri, port: null, https: true)
+            .Build();
+
+```  
+
+For the `licenseUri` use the base WordPress store address without `https:\\` (like shown above).
+
+#### LicenseInfo
+The next step is to create a `ILicenseInfo` with the details of your product created in your WooCommerece store.
+
+
+```cs
+
+    info = new LicenseInfo.LicenseInfoBuilder()
+        .WithLicense("The license key you want to check")
+        .WithOptions(new LicenseOptions()
+        {
+            ProductName = "Name of your product",
+            ProductIdentifier = "Your unique ProductId",
+            LicenseCheckPattern = "^AR-((\\w{8})-){2}(\\w{8})$",
+        })
+        .Build();
+```
+
+#### Endpoints
+If all is setup, you can perform following methods depending on your needs. All will return an `ILicenseQueryResult` object.
+
+```cs
+    ILicenseQueryResult result = await manager.CheckLicenseAsync(license: info, LicenseServerTarget.WooCommerce);
+    Assert.IsTrue(result?.Success == true);
+
+    result = await manager.DeactivateLicenseAsync(license: info, LicenseServerTarget.WooCommerce);
+    Assert.IsTrue(result?.Success == true);
+
+    result = await manager.CheckLicenseAsync(license: info, LicenseServerTarget.WooCommerce);
+    Assert.IsTrue(result?.Success == false);
+
+    result = await manager.ActivateLicenseAsync(license: info, LicenseServerTarget.WooCommerce);
+    Assert.IsTrue(result?.Success == true);
+```
+
+

--- a/src/SharedMauiCoreLibrary.Licensing/SharedMauiCoreLibrary.Licensing.csproj
+++ b/src/SharedMauiCoreLibrary.Licensing/SharedMauiCoreLibrary.Licensing.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<Import Project="..\..\common.props" />
 
 	<PropertyGroup>
@@ -21,19 +21,30 @@
 		<Title>MAUI-Core Shared Licensing Library</Title>
 		<Authors>Andreas Reitberger</Authors>
 		<Description>A libray used for .NET MAUI projects to manage licenses.</Description>
+		<PackageReadmeFile>README_Licensing.md</PackageReadmeFile>
 
 	</PropertyGroup>
 
 	<ItemGroup>
 	  <Compile Remove="Platforms\Android\Utilities\**" />
+	  <Compile Remove="Services\**" />
+	  <Compile Remove="Utilities\**" />
 	  <EmbeddedResource Remove="Platforms\Android\Utilities\**" />
+	  <EmbeddedResource Remove="Services\**" />
+	  <EmbeddedResource Remove="Utilities\**" />
 	  <MauiCss Remove="Platforms\Android\Utilities\**" />
+	  <MauiCss Remove="Services\**" />
+	  <MauiCss Remove="Utilities\**" />
 	  <MauiXaml Remove="Platforms\Android\Utilities\**" />
+	  <MauiXaml Remove="Services\**" />
+	  <MauiXaml Remove="Utilities\**" />
 	  <None Remove="Platforms\Android\Utilities\**" />
+	  <None Remove="Services\**" />
+	  <None Remove="Utilities\**" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
+		<None Include="..\..\README_Licensing.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -41,11 +52,6 @@
 	  <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	  <PackageReference Include="RCoreSharp" Version="1.0.9" />
 	  <PackageReference Include="RestSharp" Version="110.2.0" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <Folder Include="Services\" />
-	  <Folder Include="Utilities\" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR adds its own readme file for the `Licensing` extension.

Fixed #73