### PR TITLE
Migrated to `net8`

### DIFF
--- a/common.props
+++ b/common.props
@@ -1,7 +1,7 @@
 
 <Project>
     <PropertyGroup>
-        <Version>1.1.0</Version>
+        <Version>1.1.0-net8preview1</Version>
         <!--<PackageIcon>logo_128.png</PackageIcon>-->
         <NeutralLanguage>en</NeutralLanguage>
         <PackageProjectUrl>https://github.com/AndreasReitberger/SharedMauiCoreLibrary</PackageProjectUrl>

--- a/src/SharedMauiCoreLibrary.Licensing/SharedMauiCoreLibrary.Licensing.csproj
+++ b/src/SharedMauiCoreLibrary.Licensing/SharedMauiCoreLibrary.Licensing.csproj
@@ -2,8 +2,8 @@
 	<Import Project="..\..\common.props" />
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0;net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
@@ -48,6 +48,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.0-rc.1.9171" />
 	  <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
 	  <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	  <PackageReference Include="RestSharp" Version="110.2.0" />

--- a/src/SharedMauiCoreLibrary.Test/SharedMauiCoreLibrary.Test.csproj
+++ b/src/SharedMauiCoreLibrary.Test/SharedMauiCoreLibrary.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/SharedMauiCoreLibrary/SharedMauiCoreLibrary.csproj
+++ b/src/SharedMauiCoreLibrary/SharedMauiCoreLibrary.csproj
@@ -2,8 +2,12 @@
 	<Import Project="..\..\common.props" />
 	
 	<PropertyGroup>
+		<!--
 		<TargetFrameworks>net7.0;net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
+		-->
+		<TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
@@ -35,6 +39,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.0-rc.1.9171" />
 	  <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
 	  <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	  <PackageReference Include="RCoreSharp" Version="1.0.9" />


### PR DESCRIPTION
This PR migrates the libraries to use `net8`. Once `net8` is GA, this will be tested and merged.

Fixed #89