### PR TITLE
Update AppHostBuilderExtensions.cs

### DIFF
--- a/src/SharedMauiCoreLibrary/Hosting/AppHostBuilderExtensions.cs
+++ b/src/SharedMauiCoreLibrary/Hosting/AppHostBuilderExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Maui.Controls.Compatibility.Hosting;
-using AndreasReitberger.Shared.Core.Interfaces;
+﻿using AndreasReitberger.Shared.Core.Interfaces;
 using AndreasReitberger.Shared.Core.Localization;
 using CommunityToolkit.Maui;
 
@@ -9,7 +8,6 @@ namespace AndreasReitberger.Shared.Core.Hosting
     {
         public static MauiAppBuilder ConfigureCoreLibrary(this MauiAppBuilder builder)
         {
-            builder.UseMauiCompatibility();
             builder.UseMauiCommunityToolkit();
             return builder;
         }


### PR DESCRIPTION
This PR removes the `UseMauiCompatibility` extension method.

Fixed #119