### PR TITLE
Add common method to set `IsBusy` from the `ViewModelBase`

### DIFF
--- a/src/SharedMauiCoreLibrary/Interfaces/IViewModelBase.cs
+++ b/src/SharedMauiCoreLibrary/Interfaces/IViewModelBase.cs
@@ -10,5 +10,9 @@ namespace AndreasReitberger.Shared.Core.Interfaces
         ILauncher? Launcher { get; set; }
         IFilePicker? FilePicker { get; set; }
         #endregion
+
+        #region Methods
+        void SetBusy(bool isBusy, IDispatcher? dispatcher);
+        #endregion
     }
 }

--- a/src/SharedMauiCoreLibrary/Interfaces/IViewModelBase.cs
+++ b/src/SharedMauiCoreLibrary/Interfaces/IViewModelBase.cs
@@ -13,6 +13,7 @@ namespace AndreasReitberger.Shared.Core.Interfaces
 
         #region Methods
         void SetBusy(bool isBusy, IDispatcher? dispatcher);
+        Task? SetBusyAsync(bool isBusy, IDispatcher? dispatcher);
         #endregion
     }
 }

--- a/src/SharedMauiCoreLibrary/Models/ViewModelBase.cs
+++ b/src/SharedMauiCoreLibrary/Models/ViewModelBase.cs
@@ -67,6 +67,16 @@ namespace AndreasReitberger.Shared.Core
         }
         #endregion
 
+        #region Methods
+        public void SetBusy(bool isBusy, IDispatcher? dispatcher) => dispatcher?.Dispatch(() =>
+        {
+            if (isBusy)
+                IsBusyCounter++;
+            else
+                IsBusyCounter--;
+        });
+        #endregion
+
         #region Dispose
         /*
         public void Dispose()

--- a/src/SharedMauiCoreLibrary/Models/ViewModelBase.cs
+++ b/src/SharedMauiCoreLibrary/Models/ViewModelBase.cs
@@ -75,6 +75,13 @@ namespace AndreasReitberger.Shared.Core
             else
                 IsBusyCounter--;
         });
+        public Task? SetBusyAsync(bool isBusy, IDispatcher? dispatcher) => dispatcher?.DispatchAsync(() =>
+        {
+            if (isBusy)
+                IsBusyCounter++;
+            else
+                IsBusyCounter--;
+        });
         #endregion
 
         #region Dispose

--- a/src/SharedMauiCoreLibrary/SharedMauiCoreLibrary.csproj
+++ b/src/SharedMauiCoreLibrary/SharedMauiCoreLibrary.csproj
@@ -50,7 +50,7 @@
 	<ItemGroup>
 	  <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.14" />
 	  <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.14" />
-	  <PackageReference Include="CommunityToolkit.Maui" Version="7.0.1" />
+	  <PackageReference Include="CommunityToolkit.Maui" Version="8.0.1" />
 	  <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
 	  <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	</ItemGroup>

--- a/src/SharedNetCoreLibrary/Interfaces/IViewModelCoreBase.cs
+++ b/src/SharedNetCoreLibrary/Interfaces/IViewModelCoreBase.cs
@@ -18,5 +18,9 @@ namespace AndreasReitberger.Shared.Core.Interfaces
         bool IsPortrait { get; set; }
 
         #endregion
+
+        #region Methods
+        void SetBusy(bool isBusy);
+        #endregion
     }
 }

--- a/src/SharedNetCoreLibrary/Models/ViewModelCoreBase.cs
+++ b/src/SharedNetCoreLibrary/Models/ViewModelCoreBase.cs
@@ -70,6 +70,16 @@ namespace AndreasReitberger.Shared.Core
         }
         #endregion
 
+        #region Methods
+        public void SetBusy(bool isBusy)
+        {
+            if (isBusy)
+                IsBusyCounter++;
+            else 
+                IsBusyCounter--;
+        }
+        #endregion
+
         #region Dispose
         /*
         public void Dispose()


### PR DESCRIPTION
This PR adds a helper method to toggle the `IsBusy` state from a common source.

Fixed #159