### PR TITLE
Removed workaround for `AllowUnsafeBlocks` on net8

### DIFF
--- a/framework.maui.props
+++ b/framework.maui.props
@@ -14,9 +14,9 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<PublishReadyToRun>false</PublishReadyToRun>
 
-		<!-- Needed with latest SDK 8 version? -->
+		<!-- Needed with latest SDK 8 version? 
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-
+		-->
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>


### PR DESCRIPTION
Fixed #242 