### PR TITLE
Set `Minimum` maui version instead of fix version

### DIFF
--- a/src/SharedMauiCoreLibrary.Licensing/SharedMauiCoreLibrary.Licensing.csproj
+++ b/src/SharedMauiCoreLibrary.Licensing/SharedMauiCoreLibrary.Licensing.csproj
@@ -10,7 +10,7 @@
 		<Authors>Andreas Reitberger</Authors>
 		<Description>A libray used for .NET MAUI projects to manage licenses.</Description>
 		<PackageReadmeFile>README_Licensing.md</PackageReadmeFile>
-
+		<UseMaui>True</UseMaui>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -40,19 +40,10 @@
 		<None Include="..\..\README_Licensing.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 
-	<!-- Used for net9-->
-	<ItemGroup Condition="'$(DefineConstants.Contains(NET9))'">
-		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.120" />
-	</ItemGroup>
-
-	<!-- Used for net10-->
-	<ItemGroup Condition="'$(DefineConstants.Contains(NET10))'">
-		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.31" />
-	</ItemGroup>
-	
 	<ItemGroup>
-	  <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-	  <PackageReference Include="RestSharp" Version="113.1.0" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="[10.0.30,)" />
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+		<PackageReference Include="RestSharp" Version="113.1.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharedMauiCoreLibrary/SharedMauiCoreLibrary.csproj
+++ b/src/SharedMauiCoreLibrary/SharedMauiCoreLibrary.csproj
@@ -8,6 +8,7 @@
 		<RootNamespace>AndreasReitberger.Shared.Core</RootNamespace>
 		<Title>MAUI-Core Shared Library</Title>
 		<Description>A core libray used for our .NET MAUI libraries.</Description>
+		<UseMaui>True</UseMaui>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -33,13 +34,12 @@
 
 	<!-- Used for net9-->
 	<ItemGroup Condition="'$(DefineConstants.Contains(NET9))'">
-		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.120" />
 		<PackageReference Include="CommunityToolkit.Maui" Version="12.3.0" />
 	</ItemGroup>
 
 	<!-- Used for net10-->
 	<ItemGroup Condition="'$(DefineConstants.Contains(NET10))'">
-		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.31" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="[10.0.30,)" />
 		<PackageReference Include="CommunityToolkit.Maui" Version="14.0.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
It is not completely possible to remove the reference due to the dependency of the `CommunityToolkit.Maui` which needs at least `10.0.30`.

Fixed #345