### PR TITLE
Removed inheritance of `JsonSerializerContext`

### DIFF
--- a/src/SharedMauiCoreLibrary.Database.SQL/SourceGeneration/SqlDatabaseSourceGenerationContext.cs
+++ b/src/SharedMauiCoreLibrary.Database.SQL/SourceGeneration/SqlDatabaseSourceGenerationContext.cs
@@ -1,10 +1,9 @@
 ﻿using AndreasReitberger.Shared.Core.Database.Service;
-using AndreasReitberger.Shared.Core.SourceGeneration;
 
 namespace AndreasReitberger.Shared.Core.Database.SourceGeneration
 {
     [JsonSerializable(typeof(SqlDatabaseService))]
     [JsonSourceGenerationOptions(WriteIndented = true)]
-    public partial class SqlDatabaseSourceGenerationContext : MauiSourceGenerationContext { }
+    public partial class SqlDatabaseSourceGenerationContext : JsonSerializerContext { }
 
 }

--- a/src/SharedMauiCoreLibrary.Database.SQLite/SourceGeneration/SqliteDatabaseSourceGenerationContext.cs
+++ b/src/SharedMauiCoreLibrary.Database.SQLite/SourceGeneration/SqliteDatabaseSourceGenerationContext.cs
@@ -1,10 +1,9 @@
 ﻿using AndreasReitberger.Shared.Core.Database.Service;
-using AndreasReitberger.Shared.Core.SourceGeneration;
 
 namespace AndreasReitberger.Shared.Core.Database.SourceGeneration
 {
     [JsonSerializable(typeof(SqliteDatabaseService))]
     [JsonSourceGenerationOptions(WriteIndented = true)]
-    public partial class SqliteDatabaseSourceGenerationContext : MauiSourceGenerationContext { }
+    public partial class SqliteDatabaseSourceGenerationContext : JsonSerializerContext { }
 
 }

--- a/src/SharedMauiCoreLibrary.Licensing/SourceGeneration/LicenseSourceGenerationContext.cs
+++ b/src/SharedMauiCoreLibrary.Licensing/SourceGeneration/LicenseSourceGenerationContext.cs
@@ -21,6 +21,6 @@ namespace AndreasReitberger.Shared.Core.Licensing.SourceGeneration
     [JsonSerializable(typeof(WooActivationResponse[]))]
     [JsonSerializable(typeof(WooCodeVersionResponse[]))]
     [JsonSourceGenerationOptions(WriteIndented = true)]
-    public partial class LicenseSourceGenerationContext : CoreSourceGenerationContext { }
+    public partial class LicenseSourceGenerationContext : JsonSerializerContext { }
 
 }

--- a/src/SharedMauiCoreLibrary.Test/CoreTests.cs
+++ b/src/SharedMauiCoreLibrary.Test/CoreTests.cs
@@ -1,4 +1,6 @@
-﻿using AndreasReitberger.Shared.Core.Utilities;
+﻿using AndreasReitberger.Shared.Core.SourceGeneration;
+using AndreasReitberger.Shared.Core.Utilities;
+using SharedMauiCoreLibrary.Test.Models;
 
 namespace SharedMauiCoreLibrary.Test;
 
@@ -102,6 +104,32 @@ public class LicenseTests
             var t2 = EncryptionManager.DecryptStringFromBase64String(t, decryptedPassphrase);
 
             Assert.That(plainText, Is.EqualTo(t2));
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail(ex.Message);
+        }
+    }
+
+    [Test]
+    public void JsonSerializerCombineTest()
+    {
+        try
+        {
+            TestModel tm = new()
+            {
+                Name = "test",
+                IsActive = true,
+                Start = DateTime.Now.AddHours(-1),
+                End = DateTime.Now,
+                Items = ["Item1", "Item2", "Item3"]
+            };
+            var combinedOptions = JsonOptionsProvider.CombinedOptions(SourceGeneration.TestContext.Default, CoreSourceGenerationContext.Default, MauiSourceGenerationContext.Default);
+            string? json = JsonConvertHelper.ToSettingsString(tm, options: combinedOptions);
+            Assert.That(!string.IsNullOrEmpty(json));
+
+            TestModel? tm2 = JsonConvertHelper.ToObject<TestModel>(json, options: combinedOptions);
+            Assert.That(tm2, Is.Not.Null);
         }
         catch (Exception ex)
         {

--- a/src/SharedMauiCoreLibrary.Test/Models/TestModel.cs
+++ b/src/SharedMauiCoreLibrary.Test/Models/TestModel.cs
@@ -1,0 +1,27 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using System.Collections.ObjectModel;
+
+namespace SharedMauiCoreLibrary.Test.Models
+{
+    public partial class TestModel : ObservableObject
+    {
+        #region Properties
+
+        [ObservableProperty]
+        public partial string Name { get; set; } = string.Empty;
+
+        [ObservableProperty]
+        public partial bool IsActive { get; set;  }
+
+        [ObservableProperty]
+        public partial DateTimeOffset Start { get; set; }
+
+        [ObservableProperty]
+        public partial DateTimeOffset End { get; set; }
+
+        [ObservableProperty]
+        public partial ObservableCollection<string> Items { get; set; } = [];
+
+        #endregion
+    }
+}

--- a/src/SharedMauiCoreLibrary.Test/SourceGeneration/TestContext.cs
+++ b/src/SharedMauiCoreLibrary.Test/SourceGeneration/TestContext.cs
@@ -1,0 +1,11 @@
+﻿using SharedMauiCoreLibrary.Test.Models;
+using System.Text.Json.Serialization;
+
+namespace SharedMauiCoreLibrary.Test.SourceGeneration
+{
+    [JsonSerializable(typeof(TestModel))]
+    [JsonSourceGenerationOptions(WriteIndented = true)]
+    public partial class TestContext : JsonSerializerContext
+    {
+    }
+}

--- a/src/SharedMauiCoreLibrary/SourceGeneration/MauiSourceGenerationContext.cs
+++ b/src/SharedMauiCoreLibrary/SourceGeneration/MauiSourceGenerationContext.cs
@@ -18,6 +18,6 @@ namespace AndreasReitberger.Shared.Core.SourceGeneration
     [JsonSerializable(typeof(ThemeColorInfo))]
     [JsonSerializable(typeof(ColorPickerElement))]
     [JsonSourceGenerationOptions(WriteIndented = true)]
-    public partial class MauiSourceGenerationContext : CoreSourceGenerationContext { }
+    public partial class MauiSourceGenerationContext : JsonSerializerContext { }
 
 }

--- a/src/SharedNetCoreLibrary/Utilities/JsonConvertHelper.cs
+++ b/src/SharedNetCoreLibrary/Utilities/JsonConvertHelper.cs
@@ -1,21 +1,26 @@
 ﻿
+
+#if NET6_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
+
 namespace AndreasReitberger.Shared.Core.Utilities
 {
     public partial class JsonConvertHelper
     {
         #region Converts
-        public static T? ToObject<T>(string? jsonString, T? defaultValue = default, Action<Exception>? OnError = null, JsonSerializerContext? settings = null)
+        public static T? ToObject<T>(string? jsonString, T? defaultValue = default, Action<Exception>? OnError = null, JsonSerializerContext? context = null)
         {
             try
             {
                 if (jsonString is null)
                     return defaultValue;
-                settings ??= CoreSourceGenerationContext.Default;
+                context ??= CoreSourceGenerationContext.Default;
                 // Check if it is saved as plain string. If so, just return the string
                 if (typeof(T) == typeof(string) && !(jsonString.StartsWith('"') && jsonString.EndsWith('"')))
                     return (T)Convert.ChangeType(jsonString, typeof(T));
                 else
-                    return (T?)JsonSerializer.Deserialize(jsonString, typeof(T), settings) ?? defaultValue;
+                    return (T?)JsonSerializer.Deserialize(jsonString, typeof(T), context) ?? defaultValue;
             }
             catch (Exception exc)
             {
@@ -24,13 +29,56 @@ namespace AndreasReitberger.Shared.Core.Utilities
             }
         }
 
-        public static string? ToSettingsString<T>(T? settingsObject, string? defaultValue = default, Action<Exception>? OnError = null, JsonSerializerContext? settings = null)
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("This function is not AOT safe. Use the `JsonSerializerContext` instead")]
+        [RequiresDynamicCode("This function is not AOT safe. Use the `JsonSerializerContext` instead")]
+#endif
+        public static T? ToObject<T>(string? jsonString, JsonSerializerOptions? options, T? defaultValue = default, Action<Exception>? OnError = null)
+        {
+            try
+            {
+                if (jsonString is null)
+                    return defaultValue;
+                options ??= CoreSourceGenerationContext.Default.Options;
+                // Check if it is saved as plain string. If so, just return the string
+                if (typeof(T) == typeof(string) && !(jsonString.StartsWith('"') && jsonString.EndsWith('"')))
+                    return (T)Convert.ChangeType(jsonString, typeof(T));
+                else
+                    return JsonSerializer.Deserialize<T>(jsonString, options) ?? defaultValue;
+            }
+            catch (Exception exc)
+            {
+                OnError?.Invoke(exc);
+                return defaultValue;
+            }
+        }
+
+        public static string? ToSettingsString<T>(T? settingsObject, string? defaultValue = default, Action<Exception>? OnError = null, JsonSerializerContext? context = null)
         {
             try
             {
                 if (settingsObject is null) return defaultValue;
-                settings ??= CoreSourceGenerationContext.Default;
-                return JsonSerializer.Serialize(settingsObject, typeof(T), settings) ?? defaultValue;
+                context ??= CoreSourceGenerationContext.Default;
+                return JsonSerializer.Serialize(settingsObject, typeof(T), context) ?? defaultValue;
+            }
+            catch (Exception exc)
+            {
+                OnError?.Invoke(exc);
+                return defaultValue;
+            }
+        }
+
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("This function is not AOT safe. Use the `JsonSerializerContext` instead")]
+        [RequiresDynamicCode("This function is not AOT safe. Use the `JsonSerializerContext` instead")]
+#endif
+        public static string? ToSettingsString<T>(T? settingsObject, JsonSerializerOptions? options, string? defaultValue = default, Action<Exception>? OnError = null)
+        {
+            try
+            {
+                if (settingsObject is null) return defaultValue;
+                options ??= CoreSourceGenerationContext.Default.Options;
+                return JsonSerializer.Serialize(settingsObject, options) ?? defaultValue;
             }
             catch (Exception exc)
             {

--- a/src/SharedNetCoreLibrary/Utilities/JsonOptionsProvider.cs
+++ b/src/SharedNetCoreLibrary/Utilities/JsonOptionsProvider.cs
@@ -1,0 +1,31 @@
+﻿
+using System.Text.Json.Serialization.Metadata;
+
+namespace AndreasReitberger.Shared.Core.Utilities
+{
+    public partial class JsonOptionsProvider
+    {
+        #region Converts
+
+        public static JsonSerializerOptions CombinedOptions(params IJsonTypeInfoResolver[] resolvers)
+        {
+            return new JsonSerializerOptions
+            {
+                TypeInfoResolver = CombineResolvers(resolvers)
+            };
+        }
+
+        public static IJsonTypeInfoResolver? CombineResolvers(params IJsonTypeInfoResolver[] resolvers)
+        {
+            try
+            {
+                return JsonTypeInfoResolver.Combine(resolvers);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
This PR adds a new `JsonOptionsProvider` allowing to combine `JsonSerialzeContext`. However, this will require unsafe code.

Fixed #449